### PR TITLE
test_ad9166.py: remove redundant imports

### DIFF
--- a/bindings/python/test/test_ad9166.py
+++ b/bindings/python/test/test_ad9166.py
@@ -1,9 +1,5 @@
-import pytest
-
 import iio
 import ad9166
-import os
-import pathlib
 
 ctx = iio.Context("local:")
 dev = ctx.find_device("ad9166")


### PR DESCRIPTION
Do not force the user to install unnecessary libraries.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>