### PR TITLE
Make bindings more pythonic

### DIFF
--- a/bindings/python/ad9166.py
+++ b/bindings/python/ad9166.py
@@ -60,17 +60,23 @@ else:
 
 _lib = _cdll(find_library(_libad9166), use_errno=True, use_last_error=True)
 
+
 class CalibrationParameters(Structure):
-     _fields_ = [
+    _fields_ = [
         ("Freqs", _POINTER(c_double)),
         ("Offsets", _POINTER(c_double)),
         ("Gains", _POINTER(c_double)),
         ("Len", c_size_t),
     ]
 
+
 _ad9166_context_find_calibration_data = _lib.ad9166_context_find_calibration_data
 _ad9166_context_find_calibration_data.restype = c_int
-_ad9166_context_find_calibration_data.argtypes = (_ContextPtr, _POINTER(c_char), _POINTER(_POINTER(CalibrationParameters)))
+_ad9166_context_find_calibration_data.argtypes = (
+    _ContextPtr,
+    _POINTER(c_char),
+    _POINTER(_POINTER(CalibrationParameters)),
+)
 _ad9166_context_find_calibration_data.errcheck = _check_negative
 
 _ad9166_device_set_amplitude = _lib.ad9166_device_set_amplitude
@@ -85,7 +91,11 @@ _ad9166_channel_set_frequency.errcheck = _check_negative
 
 _ad9166_device_set_iofs = _lib.ad9166_device_set_iofs
 _ad9166_device_set_iofs.restype = c_int
-_ad9166_device_set_iofs.argtypes = (_DevicePtr, _POINTER(CalibrationParameters), c_ulonglong)
+_ad9166_device_set_iofs.argtypes = (
+    _DevicePtr,
+    _POINTER(CalibrationParameters),
+    c_ulonglong,
+)
 _ad9166_device_set_iofs.errcheck = _check_negative
 
 
@@ -146,5 +156,6 @@ def device_set_iofs(dev: iio.Device, data: CalibrationParameters, frequency: int
         raise Exception("frequency must be an integer")
 
     ret = _ad9166_device_set_iofs(dev._device, data, c_ulonglong(int(frequency)))
+
     if ret != 0:
         raise Exception(f"Setting IOFS failed. ERROR: {ret}")

--- a/bindings/python/ad9166.py
+++ b/bindings/python/ad9166.py
@@ -88,19 +88,25 @@ _ad9166_device_set_iofs.restype = c_int
 _ad9166_device_set_iofs.argtypes = (_DevicePtr, _POINTER(CalibrationParameters), c_ulonglong)
 _ad9166_device_set_iofs.errcheck = _check_negative
 
-def find_calibration_data(ctx: iio.Context, name: str, data: CalibrationParameters):
+
+def find_calibration_data(ctx: iio.Context, name: str):
     """Calibration configuration.
     :param: iio.Context dev: IIO Context of AD9166 driver
     :param str name: Desired name of the device
-    :param CalibrationParameters data: Calibration parameters
+    :return: CalibrationParameters: Calibration parameters
     """
 
-    ret = _ad9166_context_find_calibration_data(ctx._context, c_char_p(str(name).encode('utf-8')), byref(data))
+    data = _POINTER(CalibrationParameters)()
+
+    ret = _ad9166_context_find_calibration_data(
+        ctx._context, c_char_p(str(name).encode("utf-8")), byref(data)
+    )
 
     if ret != 0:
         raise Exception(f"Loading Calibration data failed. ERROR: {ret}")
 
-    return ret
+    return data
+
 
 def set_amplitude(dev: iio.Device, amplitude: int):
     """Amplitude configuration.
@@ -115,7 +121,6 @@ def set_amplitude(dev: iio.Device, amplitude: int):
     if ret != 0:
         raise Exception(f"Setting amplitude failed. ERROR: {ret}")
 
-    return ret
 
 def set_frequency(ch: iio.Channel, frequency: int):
     """Frequency configuration.
@@ -130,7 +135,6 @@ def set_frequency(ch: iio.Channel, frequency: int):
     if ret != 0:
         raise Exception(f"Setting frequency failed. ERROR: {ret}")
 
-    return ret
 
 def device_set_iofs(dev: iio.Device, data: CalibrationParameters, frequency: int):
     """IOFS configuration.
@@ -144,5 +148,3 @@ def device_set_iofs(dev: iio.Device, data: CalibrationParameters, frequency: int
     ret = _ad9166_device_set_iofs(dev._device, data, c_ulonglong(int(frequency)))
     if ret != 0:
         raise Exception(f"Setting IOFS failed. ERROR: {ret}")
-
-    return ret

--- a/bindings/python/test/test_ad9166.py
+++ b/bindings/python/test/test_ad9166.py
@@ -13,9 +13,7 @@ def test_set_calibrated_amplitude_frequency(iio_uri):
     ad9166.set_amplitude(dev, -10)
     ad9166.set_frequency(ch, 3000000000)
 
-    data = ad9166._POINTER(ad9166.CalibrationParameters)()
-
-    ad9166.find_calibration_data(ctx, "cn0511", data)
+    data = ad9166.find_calibration_data(ctx, "cn0511")
 
     print(data.contents.Freqs.contents)
 

--- a/bindings/python/test/test_ad9166.py
+++ b/bindings/python/test/test_ad9166.py
@@ -3,6 +3,7 @@ import pytest
 import iio
 import ad9166
 
+
 @pytest.mark.iio_hardware(["ad9166"])
 def test_set_calibrated_amplitude_frequency(iio_uri):
     ctx = iio.Context(iio_uri)


### PR DESCRIPTION
PR updates the python bindings to be more pythonic and avoid the use of external ctypes the user has to see.

Black was also used to format the python code for consistency.