### PR TITLE
python: hide pointer calls from the user

### DIFF
--- a/bindings/python/ad9166.py
+++ b/bindings/python/ad9166.py
@@ -88,19 +88,20 @@ _ad9166_device_set_iofs.restype = c_int
 _ad9166_device_set_iofs.argtypes = (_DevicePtr, _POINTER(CalibrationParameters), c_ulonglong)
 _ad9166_device_set_iofs.errcheck = _check_negative
 
-def find_calibration_data(ctx: iio.Context, name: str, data: CalibrationParameters):
+def find_calibration_data(ctx: iio.Context, name: str):
     """Calibration configuration.
     :param: iio.Context dev: IIO Context of AD9166 driver
     :param str name: Desired name of the device
     :param CalibrationParameters data: Calibration parameters
     """
 
+    data = _POINTER(CalibrationParameters)()
     ret = _ad9166_context_find_calibration_data(ctx._context, c_char_p(str(name).encode('utf-8')), byref(data))
 
     if ret != 0:
         raise Exception(f"Loading Calibration data failed. ERROR: {ret}")
 
-    return ret
+    return data
 
 def set_amplitude(dev: iio.Device, amplitude: int):
     """Amplitude configuration.

--- a/bindings/python/test/test_ad9166.py
+++ b/bindings/python/test/test_ad9166.py
@@ -13,9 +13,7 @@ def test_set_calibrated_amplitude_frequency(iio_uri):
     ad9166.set_amplitude(dev, -10)
     ad9166.set_frequency(ch, 3000000000)
 
-    data = ad9166._POINTER(ad9166.CalibrationParameters)()
-
-    ad9166.find_calibration_data(ctx, "cn0511", data)
+    data = ad9166.find_calibration_data(ctx, "cn0511")
 
     print(data.contents.Freqs.contents)
 


### PR DESCRIPTION
The "find_calibration_data" function returns the
CalibrationParameters structure instead of being passed as argument to
the function.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>