### PR TITLE
Solved segmentation error for uncalibrated boards.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,34 +30,20 @@ As with many open source packages, we use [GitHub](https://github.com/analogdevi
 If you use it, and like it - please let us know. If you use it, and hate it - please let us know that too. The goal of the project is to try to make Linux IIO devices easier to use on a variety of platforms. If we aren't doing that - we will try to make it better.
 
 
-## Building & Installing
-
-should be a quick matter of `cmake`, then `make`, then `make install`:
+## Building & Installing libad9166 on LINUX
 
 ```
-rgetz@pinky:~/libad9166-iio$ cmake ./CMakeLists.txt
--- The C compiler identification is GNU 4.7.2
--- Check for working C compiler: /usr/bin/gcc
--- Check for working C compiler: /usr/bin/gcc -- works
--- Detecting C compiler ABI info
--- Detecting C compiler ABI info - done
--- Configuring done
--- Generating done
--- Build files have been written to: /home/rgetz/libad9166-iio
-rgetz@pinky:~/libad9166-iio$ make
-Scanning dependencies of target ad9166
-[100%] Building C object CMakeFiles/ad9166.dir/ad9166_multichip_sync.c.o
-Linking C shared library libad9166.so
-Copying OS X content Headers/ad9166.h
-[100%] Built target ad9166
-rgetz@pinky:~/libad9166-iio$ sudo make install
-[sudo] password for rgetz: 
-[100%] Built target ad9166
-Install the project...
--- Install configuration: ""
--- Installing: /usr/local/lib/pkgconfig/libad9166.pc
--- Installing: /usr/local/lib/libad9166.so.0.1
--- Installing: /usr/local/lib/libad9166.so.0
--- Installing: /usr/local/lib/libad9166.so
--- Installing: /usr/local/include/ad9166.h
+cd libad9166-iio/
+sudo cmake ./CMakeLists.txt
+sudo make
+sudo make install
+```
+
+## Building & Installing python bindings on LINUX
+```
+cd bindings/python
+sudo pip install -r requirements_dev.txt
+cmake ./CMakeLists.txt
+sudo make
+sudo make install
 ```

--- a/ad9166.c
+++ b/ad9166.c
@@ -20,6 +20,43 @@
 #define MAX_CALIB_LENGTH	32
 #define ARRAY_DELIM " [,]"
 
+double default_calibration_freqs[32] = {
+	100000000, 430000000, 510000000, 850000000, 1240000000, 2250000000,
+	2790000000, 3040000000, 3140000000, 3220000000, 3360000000, 3460000000,
+	3560000000, 3630000000, 3720000000, 3810000000, 3850000000, 3950000000,
+	4000000000, 4070000000, 4120000000, 4180000000, 4260000000, 4360000000,
+	4440000000, 4730000000, 4860000000, 5010000000, 5110000000, 5670000000,
+	5730000000, 5860000000
+};
+
+double default_calibration_offsets[32] = {
+	260, 293, 321, 288, 291, 345, 407, 474, 443, 491, 516, 493, 534, 642,
+	557, 606, 598, 645, 614, 627, 614, 655, 647, 682, 645, 714, 688, 763,
+	749, 874, 917, 899
+};
+
+double default_calibration_gains[32] = {
+	1.2565445026178007e-07, 3.3544921875e-07, -1.0769329565887484e-07,
+	1.4522821576763486e-08, 5.306764986122042e-08, 1.0081510081510082e-07,
+	2.5736040609137073e-07, -3.1037234042553216e-07, 5.852272727272726e-07,
+	2.305418719211822e-07, -2.2881355932203387e-07, 3.6219512195121936e-07,
+	1.3952119309262202e-06, -9.388185654008449e-07, 5.782520325203256e-07,
+	-2.974137931034482e-07, 4.2547169811320736e-07, -5.426751592356699e-07,
+	1.4285714285714287e-07, -1.454545454545454e-07, 9.879807692307702e-07,
+	-1.220930232558139e-07, 5.582608695652176e-07, -4.986979166666671e-07,
+	2.2954699121027734e-07, -1.391025641025642e-07, 4.4178082191780847e-07,
+	-1.272727272727272e-07, 2.0280612244898007e-07, 7.956521739130434e-07,
+	-4.520917678812415e-08, 8.961038961038966e-07
+};
+
+struct ad9166_calibration_data default_calibration_data = {
+	.freqs = default_calibration_freqs,
+	.offsets = default_calibration_offsets,
+	.gains = default_calibration_gains,
+	.len = 32,
+	.calibrated = false,
+};
+
 static int parse_array(const char *value, double **arr, size_t *len)
 {
 	char *value_dup = util_strdup(value);
@@ -48,8 +85,8 @@ err:
 }
 
 int ad9166_context_find_calibration_data(struct iio_context *ctx,
-					 const char *name,
-					 struct ad9166_calibration_data **data)
+		const char *name,
+		struct ad9166_calibration_data **data)
 {
 	char freq_attr_name[MAX_ATTR_NAME];
 	char offset_attr_name[MAX_ATTR_NAME];
@@ -66,6 +103,11 @@ int ad9166_context_find_calibration_data(struct iio_context *ctx,
 
 	size_t freqs_len, offsets_len, gains_len;
 	double *freqs, *offsets, *gains;
+
+	if (!freq_attr || !offset_attr || !gain_attr) {
+		*data = &default_calibration_data;
+		return 0;
+	}
 
 	ret = parse_array(freq_attr, &freqs, &freqs_len);
 	if (ret)
@@ -87,6 +129,7 @@ int ad9166_context_find_calibration_data(struct iio_context *ctx,
 	(*data)->offsets = offsets;
 	(*data)->gains = gains;
 	(*data)->len = freqs_len;
+	(*data)->calibrated = true;
 
 	return 0;
 }
@@ -125,6 +168,9 @@ int ad9166_device_set_iofs(struct iio_device *dev,
 {
 	int ret;
 
+	if (!data)
+		return -EINVAL;
+
 	if (data->len < 1)
 		return -EINVAL;
 
@@ -154,4 +200,9 @@ int ad9166_device_set_iofs(struct iio_device *dev,
 		return ret;
 
 	return 0;
+}
+
+bool ad9166_device_is_calibrated(struct ad9166_calibration_data *data)
+{
+	return (data->calibrated);
 }

--- a/ad9166.h
+++ b/ad9166.h
@@ -7,6 +7,7 @@
 #define __AD9166_H__
 
 #include <stddef.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,6 +42,7 @@ struct ad9166_calibration_data {
 	double *offsets;
 	double *gains;
 	size_t len;
+	bool calibrated;
 };
 
 /* ---------------------------------------------------------------------------*/
@@ -61,6 +63,8 @@ __api int ad9166_device_set_amplitude(struct iio_device *dev,
 __api int ad9166_device_set_iofs(struct iio_device *dev,
 				 struct ad9166_calibration_data *data,
 				 unsigned long long int freq);
+
+__api bool ad9166_device_is_calibrated(struct ad9166_calibration_data *data);
 
 /** @} */
 

--- a/bindings/python/ad9166.py
+++ b/bindings/python/ad9166.py
@@ -17,6 +17,7 @@ from iio import _ContextPtr, _DevicePtr, _ChannelPtr
 # pylint: disable=protected-access
 from ctypes import (
     byref,
+    c_bool,
     c_ubyte,
     c_double,
     c_int,
@@ -67,6 +68,7 @@ class CalibrationParameters(Structure):
         ("Offsets", _POINTER(c_double)),
         ("Gains", _POINTER(c_double)),
         ("Len", c_size_t),
+        ("Calibrated", c_bool),
     ]
 
 
@@ -98,6 +100,9 @@ _ad9166_device_set_iofs.argtypes = (
 )
 _ad9166_device_set_iofs.errcheck = _check_negative
 
+_ad9166_device_get_calibrated = _lib.ad9166_device_is_calibrated
+_ad9166_device_get_calibrated.restype = c_bool
+_ad9166_device_get_calibrated.argtypes =(_POINTER(CalibrationParameters),)
 
 def find_calibration_data(ctx: iio.Context, name: str):
     """Calibration configuration.
@@ -159,3 +164,9 @@ def device_set_iofs(dev: iio.Device, data: CalibrationParameters, frequency: int
 
     if ret != 0:
         raise Exception(f"Setting IOFS failed. ERROR: {ret}")
+
+def device_is_calibrated(data: CalibrationParameters):
+    """Returns true/false if board is calibrated.
+    :param CalibrationParameters data: Calibration parameters
+    """
+    return _ad9166_device_get_calibrated(data)


### PR DESCRIPTION
- libad9166 was modified to support uncalibrated boards.
- was added a variable that tracks if the board was calibrated or not (this
is used in pyadi-iio)