### PR TITLE
Add CODEOWNERS and PULL_REQUEST_TEMPLATE files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,21 @@
+# This document lists the code owners for libad9166-iio repo sources, being used
+# whenever new Pull Requests are created.
+#  - People listed in CODEOWNERS are automatically added as reviewers to all
+#    PRs open to branches containing this file, depending on the changed folders.
+#  - In addition to Code Owners, other reviewers can be added.
+#  - There can be different code owners for different branches.
+#  - PRs will require the approval of at least one code owner.
+#
+# For more details, you can refer to 
+# https://github.blog/2017-07-06-introducing-code-owners/
+#
+# The format of CODEOWNERS is: <pattern> + <mail address of one/more owners>
+# In case of multiple matches, the last pattern matched will take precedence.
+
+##### Global code owners (for folders with no later match) #####
+*    cristina.suteu@analog.com dan.nechita@analog.com michael.hennerich@analog.com
+
+##### Code owners for CI related files/folders #####
+/CI/	cristina.suteu@analog.com dan.nechita@analog.com michael.hennerich@analog.com stefan.raus@analog.com andreea.andrisan@analog.com
+azure-pipelines.yml	cristina.suteu@analog.com dan.nechita@analog.com michael.hennerich@analog.com stefan.raus@analog.com andreea.andrisan@analog.com
+appveyor.yml	cristina.suteu@analog.com dan.nechita@analog.com michael.hennerich@analog.com stefan.raus@analog.com andreea.andrisan@analog.com

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## PR Description
+
+- Please replace this comment with a summary of your changes, and add any context 
+necessary to understand them. List any dependencies required for this change.
+- To check the checkboxes below, insert a 'x' between square brackets (without 
+any space), or simply check them after publishing the PR.
+- If you changes include a breaking change, please specify dependent PRs in the 
+description and try to push all related PRs simultaneously.
+
+## PR Type
+- [ ] Bug fix (a change that fixes an issue)
+- [ ] New feature (a change that adds new functionality)
+- [ ] Breaking change (a change that affects other repos or cause CIs to fail)
+
+## PR Checklist
+- [ ] I have followed the coding standards and guidelines
+- [ ] I have conducted a self-review of my own code changes
+- [ ] I have commented new code, particulary complex or unclear areas 
+- [ ] I have built libad9166-iio and check no new warnings/errors were introduced
+- [ ] I have checked that my changes did not broke components that use libad9361-iio as dependency
+- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)


### PR DESCRIPTION
Persons specified in **CODEOWNERS** file will be automatically added as reviewers, whenever new PRs are opened, depending on affected files/folders. In addition to Code Owners, other reviewers can be added to each PR. CODEOWNERS file can be different from one branch to another. All new PRs will require the approval of at least one code owner.

**PULL_REQUEST_TEMPLATE.md** will populate all new PR description field. Beside PR description, it contains a list of checkboxes, ensuring everyone follows the same guidelines and enforces best practices. Pull Request Template applies for PRs against all protected branches.

Both files got added in .github