### PR TITLE
Update ad9166 test

### DIFF
--- a/bindings/python/test/test_ad9166.py
+++ b/bindings/python/test/test_ad9166.py
@@ -12,7 +12,7 @@ def test_set_calibrated_amplitude_frequency(iio_uri):
     ch = dev.find_channel("altvoltage0", True)
 
     ad9166.set_amplitude(dev, -10)
-    ad9166.set_frequency(ch, 3000000000)
+    ad9166.set_frequency(ch, 2100000000)
 
     data = ad9166.find_calibration_data(ctx, "cn0511")
 


### PR DESCRIPTION
## PR Description

This change includes an update on the frequency value being set by the set_frequency() function. The fix was made due to the issue produced by the previous value, 3000000000, which is "No such device" error. Also, any value close to 3000000000 and higher causes this error. The value being set now is 2100000000.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have followed the coding standards and guidelines
- [ ] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particulary complex or unclear areas 
- [ ] I have built libad9166-iio and check no new warnings/errors were introduced
- [ ] I have checked that my changes did not broke components that use libad9361-iio as dependency
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
