### PR TITLE
[FREEZED Until V1 Migration is Done] Setup azure resource trigger

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,6 +22,16 @@ trigger:
     - staging/*
     - 20*
 
+resources:
+  pipelines:
+  - pipeline: triggered_by_libiio
+    source: analogdevicesinc.libiio
+    project: OpenSource
+    trigger:
+      branches:
+       include:
+       - main
+
 pr:
   branches:
     include:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,17 +1,20 @@
 variables:
-  libiioPipelineId: 9
-  isMain: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
-
+- group: Secrets
+- name: libiioPipelineId
+  value: 9
+- name: downloadBranch
   ${{ if eq(variables['Build.SourceBranchName'], 'libad9166-iio-v0') }}:
-    downloadBranch: 'refs/heads/libiio-v0'
+    value: 'refs/heads/libiio-v0'
   ${{ elseif eq(variables['Build.SourceBranchName'], 'next_stable') }}:
-    downloadBranch: 'refs/heads/next_stable'
+    value: 'refs/heads/next_stable'
   ${{ elseif startsWith(variables['Build.SourceBranchName'], '20') }}:
-    downloadBranch: $(Build.SourceBranch)
+    value: $(Build.SourceBranch)
   ${{ elseif eq(variables['Build.Reason'], 'PullRequest') }}:
-    downloadBranch: $[ format('refs/heads/{0}',replace(variables['System.PullRequest.TargetBranch'], 'libad9166-iio-v0', 'libiio-v0')) ]
+    value: $[ format('refs/heads/{0}',replace(variables['System.PullRequest.TargetBranch'], 'libad9166-iio-v0', 'libiio-v0')) ]
   ${{ else }}:
-    downloadBranch: 'refs/heads/main'
+    value: 'refs/heads/main'
+- name: isMain
+  value: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
 
 trigger:
   branches:
@@ -39,342 +42,390 @@ pr:
     - next_stable
     - libad9166-iio-v0
     - 20*
+stages:
+- stage: Run_Libad9166_Builds
+  displayName: Run Libad9166-iio Builds
+  jobs:
+  - job: LinuxBuilds
+    pool:
+        vmImage: 'ubuntu-latest'
+    strategy:
+      matrix:
+        ubuntu_20_04_x86_64:
+          image: 'tfcollins/libiio_ubuntu_20_04-ci:latest'
+          artifactName: 'Linux-Ubuntu-20.04'
+          build_script: ci-linux.sh
+          OS_TYPE: default
+          PACKAGE_TO_INSTALL: '/ci/build/*.deb'
+        ubuntu_22_04_x86_64:
+          image: 'tfcollins/libiio_ubuntu_22_04-ci:latest'
+          artifactName: 'Linux-Ubuntu-22.04'
+          build_script: ci-linux.sh
+          OS_TYPE: default
+          PACKAGE_TO_INSTALL: '/ci/build/*.deb'
+        ubuntu_24_04_x86_64:
+          image: 'tfcollins/libiio_ubuntu_24_04-ci:latest'
+          artifactName: 'Linux-Ubuntu-24.04'
+          build_script: ci-linux.sh
+          OS_TYPE: default
+          PACKAGE_TO_INSTALL: '/ci/build/*.deb'
+        debian_bullseye:
+          image: 'tfcollins/libiio_debian_bullseye-ci:latest'
+          artifactName: 'Linux-Debian-11'
+          build_script: ci-linux.sh
+          OS_TYPE: default
+          PACKAGE_TO_INSTALL: '/ci/build/*.deb'
+        debian_bookworm:
+          image: 'tfcollins/libiio_debian_bookworm-ci:latest'
+          artifactName: 'Linux-Debian-12'
+          build_script: ci-linux.sh
+          OS_TYPE: default
+          PACKAGE_TO_INSTALL: '/ci/build/*.deb'
+        fedora28:
+          image: 'tfcollins/libiio_fedora_28-ci:latest'
+          artifactName: 'Linux-Fedora-28'
+          build_script: ci-linux.sh
+          OS_TYPE: centos
+          PACKAGE_TO_INSTALL: '/ci/build/*.rpm'
+        fedora34:
+          image: 'tfcollins/libiio_fedora_34-ci:latest'
+          artifactName: 'Linux-Fedora-34'
+          build_script: ci-linux.sh
+          OS_TYPE: centos
+          PACKAGE_TO_INSTALL: '/ci/build/*.rpm'
+        opensuse_15_4:
+          image: 'tfcollins/libiio_opensuse_15_4-ci:latest'
+          artifactName: 'Linux-openSUSE-15.4'
+          build_script: ci-linux.sh
+          OS_TYPE: opensuse
+          PACKAGE_TO_INSTALL: '/ci/build/*.rpm'
+    steps:
+    - checkout: self
+      fetchDepth: 1
+      clean: true
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        source: 'specific'
+        project: '$(System.TeamProjectId)'
+        pipeline: $(libiioPipelineId)
+        artifact: '$(artifactName)'
+        runVersion: 'latestFromBranch'
+        runBranch: $(downloadBranch)
+        path: '$(Agent.BuildDirectory)/s/build/'
+    - script: |
+        set -e
+        sudo docker run --rm -t --privileged -e ARTIFACTNAME=$(artifactName) -v "$(Agent.BuildDirectory)/s":"/ci" "$(image)" /bin/bash -c "cd /ci/ && chmod +x ./CI/travis/$(build_script) && ./CI/travis/$(build_script) $(OS_TYPE) $(PACKAGE_TO_INSTALL)"
+      displayName: "Build"
+    - task: CopyFiles@2
+      inputs:
+        sourceFolder: '$(Agent.BuildDirectory)/s/build/'
+        contents: '$(Agent.BuildDirectory)/s/build/?(*.deb|*.rpm)'
+        targetFolder: '$(Build.ArtifactStagingDirectory)'
+    - task: PublishPipelineArtifact@1
+      inputs:
+        targetPath: '$(Build.ArtifactStagingDirectory)'
+        artifactName: '$(artifactName)'
+    - script: |
+        sudo pip install setuptools wheel twine build
+        cd /home/vsts/work/1/s/build/bindings/python
+        sudo python setup.py bdist_wheel
+      condition: eq(variables['artifactName'], 'Linux-Ubuntu-20.04')
+      displayName: "Install wheel and twine"
+    - task: TwineAuthenticate@1
+      condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'), eq(variables['artifactName'], 'Linux-Ubuntu-20.04'))
+      displayName: Twine Authenticate
+      inputs:
+        artifactFeed: libad9361-iio
+        pythonUploadServiceConnection: PyPi
+    - task: TwineAuthenticate@1
+      condition: and(succeeded(), eq(variables.isMain, true), eq(variables['artifactName'], 'Linux-Ubuntu-20.04'))
+      displayName: Twine Authenticate
+      inputs:
+        artifactFeed: test-libad9361-iio
+        pythonUploadServiceConnection: PyPi_Test
+    - script: |
+        cd /home/vsts/work/1/s/build/bindings/python
+        python -m twine upload -u $(USERNAME) -p $(PASSWORD) --config-file $(PYPIRC_PATH) dist/*.whl
+      condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'), eq(variables['artifactName'], 'Linux-Ubuntu-20.04'))
+      displayName: "Deploy python package" 
+    - script: |
+        cd /home/vsts/work/1/s/build/bindings/python
+        sudo rm ./dist/*.whl
+        sudo pip3 install --upgrade requests
+        sudo pip install invoke
+        sudo invoke bumpversion-test
+        sudo python -m build
+        ls -al
+        cd dist
+        ls -al
+      condition: and(succeeded(), eq(variables.isMain, true), eq(variables['artifactName'], 'Linux-Ubuntu-20.04'))
+      displayName: "Update to dev version"
+    - script: |
+        cd /home/vsts/work/1/s/build/bindings/python
+        sudo python -m twine upload --repository-url https://test.pypi.org/legacy/ -u $(USERNAME) -p $(PASSWORD) --skip-existing --config-file $(PYPIRC_PATH) dist/*.whl
+      condition: and(succeeded(), eq(variables.isMain, true), eq(variables['artifactName'], 'Linux-Ubuntu-20.04'))
+      displayName: "Deploy python test package"
+  - job: ARMBuilds
+    # Host Box
+    pool:
+      vmImage: "ubuntu-latest"
+    # Docker Images
+    strategy:
+      matrix:
+        ubuntu-ppc64le:
+          image: tfcollins/libiio_ubuntu_20_04-ci-arm-ppc:latest
+          arch: ppc64le
+          build_script: ci-ubuntu.sh
+          artifactName: 'Ubuntu-ppc64le'
+        ubuntu-x390x:
+          image: tfcollins/libiio_ubuntu_20_04-ci-arm-ppc:latest
+          arch: s390x
+          build_script: ci-ubuntu.sh
+          artifactName: 'Ubuntu-x390x'
+        debian_buster_arm32v7:
+          image: tfcollins/libiio_ubuntu_20_04-ci-arm-ppc:latest
+          arch: arm
+          build_script: ci-ubuntu.sh
+          artifactName: 'Ubuntu-arm32v7'
+        debian_buster_arm64v8:
+          image: tfcollins/libiio_ubuntu_20_04-ci-arm-ppc:latest
+          arch: aarch64
+          build_script: ci-ubuntu.sh
+          artifactName: 'Ubuntu-arm64v8'
+        debian_bookworm_arm:
+          image: tfcollins/libiio_debian_bookworm-ci-arm-ppc:latest
+          arch: arm
+          build_script: ci-ubuntu.sh
+          artifactName: 'Debian12-arm'
+    steps:
+    - checkout: self
+      fetchDepth: 1
+      clean: true
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        source: 'specific'
+        project: '$(System.TeamProjectId)'
+        pipeline: $(libiioPipelineId)
+        artifact: '$(artifactName)'
+        runVersion: 'latestFromBranch'
+        runBranch: $(downloadBranch)
+        path: '$(Agent.BuildDirectory)/s/build/'
+    - script: |
+        set -e 
+        sudo apt-get update
+        sudo apt-get install -y gcc-arm-linux-gnueabihf libc6-dev-armhf-cross
+        sudo apt-get install -y g++-arm-linux-gnueabihf
+        sudo apt-get install -y g++-aarch64-linux-gnu
+        sudo apt-get install -y qemu-system-ppc64
+        sudo apt-get install qemu binfmt-support qemu-user-static
+        sudo docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+      displayName: "Setup"
+    - script: |
+        set -e
+        sudo docker run --platform "linux/$(arch)" --rm -t --privileged -e ARTIFACTNAME=$(artifactName) -v "$(Agent.BuildDirectory)/s":"/ci" -v "/usr/bin/qemu-$(arch)-static":"/usr/bin/qemu-$(arch)-static" "$(image)" /bin/bash -c "cd /ci/ && chmod +x ./CI/travis/$(build_script) && ./CI/travis/$(build_script)"
+      displayName: "Build"
+    - task: CopyFiles@2
+      inputs:
+        sourceFolder: '$(Agent.BuildDirectory)/s/build/'
+        contents: '$(Agent.BuildDirectory)/s/build/?(*.deb|*.rpm)'
+        targetFolder: '$(Build.ArtifactStagingDirectory)'
+    - task: PublishPipelineArtifact@1
+      inputs:
+        targetPath: '$(Build.ArtifactStagingDirectory)'
+        artifactName: '$(artifactName)'
 
-jobs:
-- job: LinuxBuilds
-  pool:
-      vmImage: 'ubuntu-latest'
-  strategy:
-    matrix:
-      ubuntu_20_04_x86_64:
-        image: 'tfcollins/libiio_ubuntu_20_04-ci:latest'
-        artifactName: 'Linux-Ubuntu-20.04'
-        build_script: ci-linux.sh
-        OS_TYPE: default
-        PACKAGE_TO_INSTALL: '/ci/build/*.deb'
-      ubuntu_22_04_x86_64:
-        image: 'tfcollins/libiio_ubuntu_22_04-ci:latest'
-        artifactName: 'Linux-Ubuntu-22.04'
-        build_script: ci-linux.sh
-        OS_TYPE: default
-        PACKAGE_TO_INSTALL: '/ci/build/*.deb'
-      ubuntu_24_04_x86_64:
-        image: 'tfcollins/libiio_ubuntu_24_04-ci:latest'
-        artifactName: 'Linux-Ubuntu-24.04'
-        build_script: ci-linux.sh
-        OS_TYPE: default
-        PACKAGE_TO_INSTALL: '/ci/build/*.deb'
-      debian_bullseye:
-        image: 'tfcollins/libiio_debian_bullseye-ci:latest'
-        artifactName: 'Linux-Debian-11'
-        build_script: ci-linux.sh
-        OS_TYPE: default
-        PACKAGE_TO_INSTALL: '/ci/build/*.deb'
-      debian_bookworm:
-        image: 'tfcollins/libiio_debian_bookworm-ci:latest'
-        artifactName: 'Linux-Debian-12'
-        build_script: ci-linux.sh
-        OS_TYPE: default
-        PACKAGE_TO_INSTALL: '/ci/build/*.deb'
-      fedora28:
-        image: 'tfcollins/libiio_fedora_28-ci:latest'
-        artifactName: 'Linux-Fedora-28'
-        build_script: ci-linux.sh
-        OS_TYPE: centos
-        PACKAGE_TO_INSTALL: '/ci/build/*.rpm'
-      fedora34:
-        image: 'tfcollins/libiio_fedora_34-ci:latest'
-        artifactName: 'Linux-Fedora-34'
-        build_script: ci-linux.sh
-        OS_TYPE: centos
-        PACKAGE_TO_INSTALL: '/ci/build/*.rpm'
-      opensuse_15_4:
-        image: 'tfcollins/libiio_opensuse_15_4-ci:latest'
-        artifactName: 'Linux-openSUSE-15.4'
-        build_script: ci-linux.sh
-        OS_TYPE: opensuse
-        PACKAGE_TO_INSTALL: '/ci/build/*.rpm'
-  steps:
-  - checkout: self
-    fetchDepth: 1
-    clean: true
-  - task: DownloadPipelineArtifact@2
-    inputs:
-      source: 'specific'
-      project: '$(System.TeamProjectId)'
-      pipeline: $(libiioPipelineId)
-      artifact: '$(artifactName)'
-      runVersion: 'latestFromBranch'
-      runBranch: $(downloadBranch)
-      path: '$(Agent.BuildDirectory)/s/build/'
-  - script: |
-      set -e
-      sudo docker run --rm -t --privileged -e ARTIFACTNAME=$(artifactName) -v "$(Agent.BuildDirectory)/s":"/ci" "$(image)" /bin/bash -c "cd /ci/ && chmod +x ./CI/travis/$(build_script) && ./CI/travis/$(build_script) $(OS_TYPE) $(PACKAGE_TO_INSTALL)"
-    displayName: "Build"
-  - task: CopyFiles@2
-    inputs:
-      sourceFolder: '$(Agent.BuildDirectory)/s/build/'
-      contents: '$(Agent.BuildDirectory)/s/build/?(*.deb|*.rpm)'
-      targetFolder: '$(Build.ArtifactStagingDirectory)'
-  - task: PublishPipelineArtifact@1
-    inputs:
-      targetPath: '$(Build.ArtifactStagingDirectory)'
-      artifactName: '$(artifactName)'
-  - script: |
-      sudo pip install setuptools wheel twine build
-      cd /home/vsts/work/1/s/build/bindings/python
-      sudo python setup.py bdist_wheel
-    condition: eq(variables['artifactName'], 'Linux-Ubuntu-20.04')
-    displayName: "Install wheel and twine"
-  - task: TwineAuthenticate@1
-    condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'), eq(variables['artifactName'], 'Linux-Ubuntu-20.04'))
-    displayName: Twine Authenticate
-    inputs:
-      artifactFeed: libad9361-iio
-      pythonUploadServiceConnection: PyPi
-  - task: TwineAuthenticate@1
-    condition: and(succeeded(), eq(variables.isMain, true), eq(variables['artifactName'], 'Linux-Ubuntu-20.04'))
-    displayName: Twine Authenticate
-    inputs:
-      artifactFeed: test-libad9361-iio
-      pythonUploadServiceConnection: PyPi_Test
-  - script: |
-      cd /home/vsts/work/1/s/build/bindings/python
-      python -m twine upload -u $(USERNAME) -p $(PASSWORD) --config-file $(PYPIRC_PATH) dist/*.whl
-    condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'), eq(variables['artifactName'], 'Linux-Ubuntu-20.04'))
-    displayName: "Deploy python package" 
-  - script: |
-      cd /home/vsts/work/1/s/build/bindings/python
-      sudo rm ./dist/*.whl
-      sudo pip3 install --upgrade requests
-      sudo pip install invoke
-      sudo invoke bumpversion-test
-      sudo python -m build
-      ls -al
-      cd dist
-      ls -al
-    condition: and(succeeded(), eq(variables.isMain, true), eq(variables['artifactName'], 'Linux-Ubuntu-20.04'))
-    displayName: "Update to dev version"
-  - script: |
-      cd /home/vsts/work/1/s/build/bindings/python
-      sudo python -m twine upload --repository-url https://test.pypi.org/legacy/ -u $(USERNAME) -p $(PASSWORD) --skip-existing --config-file $(PYPIRC_PATH) dist/*.whl
-    condition: and(succeeded(), eq(variables.isMain, true), eq(variables['artifactName'], 'Linux-Ubuntu-20.04'))
-    displayName: "Deploy python test package"
-- job: ARMBuilds
-  # Host Box
-  pool:
-    vmImage: "ubuntu-latest"
-  # Docker Images
-  strategy:
-    matrix:
-      ubuntu-ppc64le:
-        image: tfcollins/libiio_ubuntu_20_04-ci-arm-ppc:latest
-        arch: ppc64le
-        build_script: ci-ubuntu.sh
-        artifactName: 'Ubuntu-ppc64le'
-      ubuntu-x390x:
-        image: tfcollins/libiio_ubuntu_20_04-ci-arm-ppc:latest
-        arch: s390x
-        build_script: ci-ubuntu.sh
-        artifactName: 'Ubuntu-x390x'
-      debian_buster_arm32v7:
-        image: tfcollins/libiio_ubuntu_20_04-ci-arm-ppc:latest
-        arch: arm
-        build_script: ci-ubuntu.sh
-        artifactName: 'Ubuntu-arm32v7'
-      debian_buster_arm64v8:
-        image: tfcollins/libiio_ubuntu_20_04-ci-arm-ppc:latest
-        arch: aarch64
-        build_script: ci-ubuntu.sh
-        artifactName: 'Ubuntu-arm64v8'
-      debian_bookworm_arm:
-        image: tfcollins/libiio_debian_bookworm-ci-arm-ppc:latest
-        arch: arm
-        build_script: ci-ubuntu.sh
-        artifactName: 'Debian12-arm'
-  steps:
-  - checkout: self
-    fetchDepth: 1
-    clean: true
-  - task: DownloadPipelineArtifact@2
-    inputs:
-      source: 'specific'
-      project: '$(System.TeamProjectId)'
-      pipeline: $(libiioPipelineId)
-      artifact: '$(artifactName)'
-      runVersion: 'latestFromBranch'
-      runBranch: $(downloadBranch)
-      path: '$(Agent.BuildDirectory)/s/build/'
-  - script: |
-      set -e 
-      sudo apt-get update
-      sudo apt-get install -y gcc-arm-linux-gnueabihf libc6-dev-armhf-cross
-      sudo apt-get install -y g++-arm-linux-gnueabihf
-      sudo apt-get install -y g++-aarch64-linux-gnu
-      sudo apt-get install -y qemu-system-ppc64
-      sudo apt-get install qemu binfmt-support qemu-user-static
-      sudo docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-    displayName: "Setup"
-  - script: |
-      set -e
-      sudo docker run --platform "linux/$(arch)" --rm -t --privileged -e ARTIFACTNAME=$(artifactName) -v "$(Agent.BuildDirectory)/s":"/ci" -v "/usr/bin/qemu-$(arch)-static":"/usr/bin/qemu-$(arch)-static" "$(image)" /bin/bash -c "cd /ci/ && chmod +x ./CI/travis/$(build_script) && ./CI/travis/$(build_script)"
-    displayName: "Build"
-  - task: CopyFiles@2
-    inputs:
-      sourceFolder: '$(Agent.BuildDirectory)/s/build/'
-      contents: '$(Agent.BuildDirectory)/s/build/?(*.deb|*.rpm)'
-      targetFolder: '$(Build.ArtifactStagingDirectory)'
-  - task: PublishPipelineArtifact@1
-    inputs:
-      targetPath: '$(Build.ArtifactStagingDirectory)'
-      artifactName: '$(artifactName)'
+  - job: macOSBuilds
+    workspace:
+      clean: all
+    strategy:
+      matrix:
+        macOS_15_x64:
+          poolName: 'Azure Pipelines'
+          vmImage: 'macOS-15'
+          agentName: 'Azure Pipelines 11'
+          artifactName: 'macOS-15-x64'
+        macOS_14_x64:
+          poolName: 'Azure Pipelines'
+          vmImage: 'macOS-14'
+          agentName: 'Azure Pipelines 3'
+          artifactName: 'macOS-14-x64'
+        macOS_13_x64:
+          poolName: 'Azure Pipelines'
+          vmImage: 'macOS-13'
+          agentName: 'Azure Pipelines 2'
+          artifactName: 'macOS-13-x64'
+        macOS_13_arm64:
+          poolName: 'Default'
+          vmImage:
+          agentName: 'miniMAC_arm64'
+          artifactName: 'macOS-13-arm64'
+    pool:
+      name: $(poolName)
+      vmImage: $(vmImage)
+      demands:
+        - agent.name -equals $(agentName)
+    variables:
+      PACKAGE_TO_INSTALL: 'build/*.pkg'
+    steps:
+    - checkout: self
+      fetchDepth: 1
+      clean: true
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        source: 'specific'
+        project: '$(System.TeamProjectId)'
+        pipeline: $(libiioPipelineId)
+        artifact: '$(artifactName)'
+        runVersion: 'latestFromBranch'
+        runBranch: $(downloadBranch)
+        path: '$(Agent.BuildDirectory)/s/build/'
+    - script: ./CI/travis/before_install_darwin
+      displayName: "Install Dependencies"
+    - script: ./CI/travis/make_darwin
+      displayName: "Build"
+    - task: CopyFiles@2
+      inputs:
+        sourceFolder: '$(Agent.BuildDirectory)/s/build/'
+        contents: '$(Agent.BuildDirectory)/s/build/?(*.pkg)'
+        targetFolder: '$(Build.ArtifactStagingDirectory)'
+    - task: PublishPipelineArtifact@1
+      inputs:
+        targetPath: '$(Build.ArtifactStagingDirectory)'
+        artifactName: '$(artifactName)'
 
-- job: macOSBuilds
-  workspace:
-    clean: all
-  strategy:
-    matrix:
-      macOS_15_x64:
-        poolName: 'Azure Pipelines'
-        vmImage: 'macOS-15'
-        agentName: 'Azure Pipelines 11'
-        artifactName: 'macOS-15-x64'
-      macOS_14_x64:
-        poolName: 'Azure Pipelines'
-        vmImage: 'macOS-14'
-        agentName: 'Azure Pipelines 3'
-        artifactName: 'macOS-14-x64'
-      macOS_13_x64:
-        poolName: 'Azure Pipelines'
-        vmImage: 'macOS-13'
-        agentName: 'Azure Pipelines 2'
-        artifactName: 'macOS-13-x64'
-      macOS_13_arm64:
-        poolName: 'Default'
-        vmImage:
-        agentName: 'miniMAC_arm64'
-        artifactName: 'macOS-13-arm64'
-  pool:
-    name: $(poolName)
-    vmImage: $(vmImage)
-    demands:
-      - agent.name -equals $(agentName)
-  variables:
-    PACKAGE_TO_INSTALL: 'build/*.pkg'
-  steps:
-  - checkout: self
-    fetchDepth: 1
-    clean: true
-  - task: DownloadPipelineArtifact@2
-    inputs:
-      source: 'specific'
-      project: '$(System.TeamProjectId)'
-      pipeline: $(libiioPipelineId)
-      artifact: '$(artifactName)'
-      runVersion: 'latestFromBranch'
-      runBranch: $(downloadBranch)
-      path: '$(Agent.BuildDirectory)/s/build/'
-  - script: ./CI/travis/before_install_darwin
-    displayName: "Install Dependencies"
-  - script: ./CI/travis/make_darwin
-    displayName: "Build"
-  - task: CopyFiles@2
-    inputs:
-      sourceFolder: '$(Agent.BuildDirectory)/s/build/'
-      contents: '$(Agent.BuildDirectory)/s/build/?(*.pkg)'
-      targetFolder: '$(Build.ArtifactStagingDirectory)'
-  - task: PublishPipelineArtifact@1
-    inputs:
-      targetPath: '$(Build.ArtifactStagingDirectory)'
-      artifactName: '$(artifactName)'
-
-- job: WindowsBuilds
-  strategy:
-    matrix:
-      VS2022:
-          imageName: 'windows-2022'
-          COMPILER: 'Visual Studio 17 2022'
+  - job: WindowsBuilds
+    strategy:
+      matrix:
+        VS2022:
+            imageName: 'windows-2022'
+            COMPILER: 'Visual Studio 17 2022'
+            ARCH: 'x64'
+            artifactName: 'Windows-VS-2022-x64'
+        VS2019_Win64:
+          imageName: 'windows-2019'
+          COMPILER: 'Visual Studio 16 2019'
           ARCH: 'x64'
-          artifactName: 'Windows-VS-2022-x64'
-      VS2019_Win64:
-        imageName: 'windows-2019'
-        COMPILER: 'Visual Studio 16 2019'
-        ARCH: 'x64'
-        artifactName: 'Windows-VS-2019-x64'
-  pool:
-    vmImage: $[ variables['imageName'] ]
-  steps:
-  - checkout: self
-    fetchDepth: 1
-    clean: true
-  - task: DownloadPipelineArtifact@2
-    inputs:
-      source: 'specific'
-      project: '$(System.TeamProjectId)'
-      pipeline: $(libiioPipelineId)
-      artifact: '$(artifactName)'
-      runVersion: 'latestFromBranch'
-      runBranch: $(downloadBranch)
-      path: '$(Agent.BuildDirectory)/s/build/'
-  - task: PowerShell@2
-    inputs:
-      targetType: 'filePath'
-      filePath: .\CI\install_deps_win.ps1
-    displayName: Dependencies
-  - task: PowerShell@2
-    inputs:
-      targetType: 'filePath'
-      filePath: .\CI\build_win.ps1
-    displayName: Build
-  - task: CopyFiles@2
-    displayName: 'Copy libraries'
-    inputs:
-      sourceFolder: '$(Agent.BuildDirectory)/s/build/Release'
-      targetFolder: '$(Build.ArtifactStagingDirectory)'
-  - task: CopyFiles@2
-    displayName: 'Copy ad9166.h header'
-    inputs:
-      sourceFolder: '$(Agent.BuildDirectory)/s/'
-      contents: 'ad9166.h'
-      targetFolder: '$(Build.ArtifactStagingDirectory)'
-  - task: CopyFiles@2
-    displayName: 'Copy .exe files'
-    inputs:
-      sourceFolder: '$(Agent.BuildDirectory)/s/build'
-      contents: '*.exe'
-      targetFolder: '$(Build.ArtifactStagingDirectory)'
-  - task: CopyFiles@2
-    displayName: 'Copy libiio.dll'
-    inputs:
-      sourceFolder: '$(Agent.BuildDirectory)/s/build'
-      contents: 'libiio.dll'
-      targetFolder: '$(Build.ArtifactStagingDirectory)'
-  - task: PowerShell@2
-    displayName: 'Copy dependencies'
-    inputs:
-      targetType: 'filePath'
-      filePath: .\CI\publish_deps.ps1
-  - task: PublishPipelineArtifact@1
-    inputs:
-      targetPath: '$(Build.ArtifactStagingDirectory)'
-      artifactName: '$(artifactName)'
-- job: GenerateSetupExe
-  dependsOn: WindowsBuilds
-  pool:
-    vmImage: 'windows-2019'
-  steps:
-  - task: DownloadPipelineArtifact@2
-    inputs:
-      path: '$(Build.ArtifactStagingDirectory)'
-  - script: |
-      ls -al D:\a\1\a
-    displayName: 'Test'
-  - task: PowerShell@2
-    inputs:
-      targetType: 'filePath'
-      filePath: .\CI\generate_exe.ps1
-    displayName: 'Generate libad9166-setup.exe'
-  - task: PublishPipelineArtifact@1
-    inputs:
-      targetPath: '$(Build.ArtifactStagingDirectory)'
-      artifactName: 'Libad9166-Setup-Exe'
+          artifactName: 'Windows-VS-2019-x64'
+    pool:
+      vmImage: $[ variables['imageName'] ]
+    steps:
+    - checkout: self
+      fetchDepth: 1
+      clean: true
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        source: 'specific'
+        project: '$(System.TeamProjectId)'
+        pipeline: $(libiioPipelineId)
+        artifact: '$(artifactName)'
+        runVersion: 'latestFromBranch'
+        runBranch: $(downloadBranch)
+        path: '$(Agent.BuildDirectory)/s/build/'
+    - task: PowerShell@2
+      inputs:
+        targetType: 'filePath'
+        filePath: .\CI\install_deps_win.ps1
+      displayName: Dependencies
+    - task: PowerShell@2
+      inputs:
+        targetType: 'filePath'
+        filePath: .\CI\build_win.ps1
+      displayName: Build
+    - task: CopyFiles@2
+      displayName: 'Copy libraries'
+      inputs:
+        sourceFolder: '$(Agent.BuildDirectory)/s/build/Release'
+        targetFolder: '$(Build.ArtifactStagingDirectory)'
+    - task: CopyFiles@2
+      displayName: 'Copy ad9166.h header'
+      inputs:
+        sourceFolder: '$(Agent.BuildDirectory)/s/'
+        contents: 'ad9166.h'
+        targetFolder: '$(Build.ArtifactStagingDirectory)'
+    - task: CopyFiles@2
+      displayName: 'Copy .exe files'
+      inputs:
+        sourceFolder: '$(Agent.BuildDirectory)/s/build'
+        contents: '*.exe'
+        targetFolder: '$(Build.ArtifactStagingDirectory)'
+    - task: CopyFiles@2
+      displayName: 'Copy libiio.dll'
+      inputs:
+        sourceFolder: '$(Agent.BuildDirectory)/s/build'
+        contents: 'libiio.dll'
+        targetFolder: '$(Build.ArtifactStagingDirectory)'
+    - task: PowerShell@2
+      displayName: 'Copy dependencies'
+      inputs:
+        targetType: 'filePath'
+        filePath: .\CI\publish_deps.ps1
+    - task: PublishPipelineArtifact@1
+      inputs:
+        targetPath: '$(Build.ArtifactStagingDirectory)'
+        artifactName: '$(artifactName)'
+  - job: GenerateSetupExe
+    dependsOn: WindowsBuilds
+    pool:
+      vmImage: 'windows-2019'
+    steps:
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        path: '$(Build.ArtifactStagingDirectory)'
+    - script: |
+        ls -al D:\a\1\a
+      displayName: 'Test'
+    - task: PowerShell@2
+      inputs:
+        targetType: 'filePath'
+        filePath: .\CI\generate_exe.ps1
+      displayName: 'Generate libad9166-setup.exe'
+    - task: PublishPipelineArtifact@1
+      inputs:
+        targetPath: '$(Build.ArtifactStagingDirectory)'
+        artifactName: 'Libad9166-Setup-Exe'
+- stage: Notify_libiio # execute only if it was triggerd by libiio pipeline
+  dependsOn: Run_Libad9166_Builds
+  condition: eq(variables['Build.Reason'], 'ResourceTrigger') # only if it was triggerd by libiio pipeline
+  jobs:
+  - job: PostJobStatus
+    pool:
+      vmImage: 'ubuntu-latest'
+    variables:
+      BUILD_PASSED: $[and(
+        eq(dependencies.Run_Libad9166_Builds.outputs['LinuxBuilds.result'], 'Succeeded'),
+        eq(dependencies.Run_Libad9166_Builds.outputs['ARMBuilds.result'], 'Succeeded'),
+        eq(dependencies.Run_Libad9166_Builds.outputs['macOSBuilds.result'], 'Succeeded'),
+        eq(dependencies.Run_Libad9166_Builds.outputs['WindowsBuilds.result'], 'Succeeded')
+        )]
+    steps:
+    - bash: |
+        SRC="$(resources.pipeline.triggered_by_libiio.pipelineName)"
+        echo "Pipeline name from resources: $SRC"
+        IFS='.' read -r OWNER REPO <<< "$SRC"
+        echo "##vso[task.setvariable variable=OWNER]$OWNER"
+        echo "##vso[task.setvariable variable=REPO]$REPO"
+      displayName: 'Extract OWNER and REPO from pipelineName'
+    - bash: |
+        echo "Sending POST request to GitHub checks endpoint..."
+        if [ "$BUILD_PASSED" != "False" ]; then
+          STATE="success"
+          DESC="All Builds have passed"
+        else
+          STATE="failure"
+          DESC="Some Builds have failed"
+        fi
+        echo "Final status: $STATE / $DESC"
+        echo "Sending status to https://api.github.com/repos/${OWNER}/${REPO}/statuses/$(resources.pipeline.triggered_by_libiio.sourceCommit)"
+        curl -sS -X POST \
+          -H "Accept: application/vnd.github.v3+json" \
+          -H "Authorization: Bearer $GITHUB_PAT" \
+          "https://api.github.com/repos/${OWNER}/${REPO}/statuses/$(resources.pipeline.triggered_by_libiio.sourceCommit)" \
+          -d "{
+            \"state\": \"$STATE\",
+            \"target_url\": \"$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)\",
+            \"description\": \"$DESC\",
+            \"context\": \"$(Build.DefinitionName)\"
+          }"
+      displayName: 'Notify GitHub: All checks have passed or failed'
+      env:
+        GITHUB_PAT: $(GITHUB_PAT)


### PR DESCRIPTION
## PR Description

This PR updates the CI/CD flow to introduce pipeline dependency management between libiio and libad9166.

Details:
- Restructured azure-pipelines.yml from a job-based model to a stage-based one.
- Added a resources block to declare pipeline dependencies.
- Introduced a dedicated notification stage for propagating build results.

**Workflow**

1. A push to libiio main branch → azure pipeline is triggered.
2. Azure pipeline builds and generates artifacts (binaries of libiio).
3. Upon successful completion, libad9166 is automatically triggered, consuming the artifacts produced by libiio.
4. Build and test results from both pipelines are reported back and displayed in the GitHub checks of libiio, ensuring end-to-end visibility.

**NOTE**: To enable communication of the libad build status to the upper build layer (libiio), the token must include the following permission:

- **Commit statuses** repository permission (**write**).

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have followed the coding standards and guidelines
- [ ] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particulary complex or unclear areas 
- [ ] I have built libad9166-iio and check no new warnings/errors were introduced
- [ ] I have checked that my changes did not broke components that use libad9361-iio as dependency
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
