### PR TITLE
Use Architecture: any instead of @ARCHITECTURE@ placeholder

### DIFF
--- a/.github/scripts/create_debian.sh
+++ b/.github/scripts/create_debian.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
 version=$1
-architecture=$(dpkg --print-architecture)
-
 source_code=$(basename "$PWD")
 
 # Use sudo only if not running as root
@@ -18,7 +16,6 @@ $SUDO apt-get install -y build-essential cmake libiio-dev python3 python3-pip py
 # Replace placeholders inside the debian template files
 sed -i "s/@VERSION@/$version-1/" packaging/debian/changelog
 sed -i "s/@DATE@/$(date -R)/" packaging/debian/changelog
-sed -i "s/@ARCHITECTURE@/$architecture/" packaging/debian/control
 
 cp -r packaging/debian .
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,7 +26,7 @@ jobs:
       app-version: ${{ steps.set_version.outputs.version }}
     steps:
     - name: Checkout code repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Set app version
       id: set_version
       run: |
@@ -59,7 +59,7 @@ jobs:
 
     steps:
     - name: Checkout code repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         path: ${{env.APP_NAME}}
 
@@ -82,7 +82,7 @@ jobs:
         ls -la ./artifacts/
 
     - name: Upload debian artifacts to github
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{env.APP_NAME}}-${{matrix.distro}}-${{matrix.architecture}}
         path: |
@@ -102,7 +102,7 @@ jobs:
         working-directory: ${{env.APP_NAME}}
     steps:
     - name: Checkout code repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         path: ${{env.APP_NAME}}
 
@@ -117,7 +117,7 @@ jobs:
         ls -la artifacts/
 
     - name: Upload debian artifacts to github
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{env.APP_NAME}}-ubuntu
         path: |

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -8,7 +8,7 @@ Homepage: https://github.com/analogdevicesinc/libad9166-iio
 Rules-Requires-Root: no
 
 Package: libad9166
-Architecture: @ARCHITECTURE@
+Architecture: any
 Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends}
 Depends: ${misc:Depends}, ${shlibs:Depends}
@@ -19,7 +19,7 @@ Description: Library of functions specific to the Analog Devices AD9166
  Analog Devices AD9166 DAC.
 
 Package: libad9166-dev
-Architecture: @ARCHITECTURE@
+Architecture: any
 Section: libdevel
 Depends: libad9166 (= ${binary:Version}), ${misc:Depends}
 Replaces: ad9166-dev


### PR DESCRIPTION
## PR Description

Let debuild detect the host architecture automatically, removing the need for placeholder substitution.

## PR Type
- [X] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have followed the coding standards and guidelines
- [ ] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particulary complex or unclear areas 
- [ ] I have built libad9166-iio and check no new warnings/errors were introduced
- [ ] I have checked that my changes did not broke components that use libad9361-iio as dependency
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
