### PR TITLE
CMakeLists: bump cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # Lesser General Public License for more details.
 
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 3.5.0)
 project(ad9166 C)
 
 set(LIBAD9166_VERSION_MAJOR 0)


### PR DESCRIPTION
cmake removed compat with versions <3.5.0
## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have followed the coding standards and guidelines
- [ ] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particulary complex or unclear areas 
- [ ] I have built libad9166-iio and check no new warnings/errors were introduced
- [ ] I have checked that my changes did not broke components that use libad9361-iio as dependency
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
